### PR TITLE
feat: make quill customizable

### DIFF
--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -2,11 +2,13 @@ import mirador from 'mirador/dist/es/src/index';
 import annotationPlugins from '../../src';
 import LocalStorageAdapter from '../../src/annotationAdapter/LocalStorageAdapter';
 import { manifestsCatalog } from './manifestsCatalog';
+import { quillConfig } from './quillConfig';
 
 const config = {
   annotation: {
     adapter: (canvasId) => new LocalStorageAdapter(`localStorage://?canvasId=${canvasId}`, 'Anonymous User'),
     exportLocalStorageAnnotations: false, // display annotation JSON export button
+    quillConfig,
   },
   annotations: {
     htmlSanitizationRuleSet: 'liberal',

--- a/demo/src/quillConfig.js
+++ b/demo/src/quillConfig.js
@@ -1,0 +1,34 @@
+export const quillConfig = {
+  // https://quilljs.com/docs/formats
+  formats: [
+    'header',
+    'bold',
+    'italic',
+    'underline',
+    'strike',
+    'blockquote',
+    'list',
+    'bullet',
+    'indent',
+    'link',
+    'image',
+    'color',
+    'background',
+  ],
+  // https://quilljs.com/docs/modules/toolbar/
+  modules: {
+    toolbar: [
+      [{ header: [1, 2, false] }],
+      ['bold', 'italic', 'underline', 'strike', 'blockquote'],
+      [
+        { list: 'ordered' },
+        { list: 'bullet' },
+        { indent: '-1' },
+        { indent: '+1' },
+      ],
+      [{ color: [] }, { background: [] }],
+      ['link', 'image'],
+      ['clean'],
+    ],
+  },
+};

--- a/src/TextEditor.js
+++ b/src/TextEditor.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import ReactQuill from 'react-quill';
 import 'react-quill/dist/quill.snow.css';
 import { styled } from '@mui/material/styles';
+import { useSelector } from 'react-redux';
+import { getConfig } from 'mirador/dist/es/src/state/selectors';
 
 const StyledReactQuill = styled(ReactQuill)(({ theme }) => ({
   '.ql-editor': {
@@ -16,7 +18,8 @@ function TextEditor({
   updateAnnotationBody,
 }) {
   const [editorHtml, setEditorHtml] = useState(annoHtml);
-
+  const annotationConfig = useSelector((state) => getConfig(state)).annotation;
+  const { formats, modules } = annotationConfig.quillConfig;
   /**
    * Handle Change On ReactQuil Editor
    * @param html
@@ -27,37 +30,6 @@ function TextEditor({
       updateAnnotationBody(html);
     }
   };
-  const modules = {
-    toolbar: [
-      [{ header: [1, 2, false] }],
-      ['bold', 'italic', 'underline', 'strike', 'blockquote'],
-      [
-        { list: 'ordered' },
-        { list: 'bullet' },
-        { indent: '-1' },
-        { indent: '+1' },
-      ],
-      [{ color: [] }, { background: [] }],
-      ['link', 'image'],
-      ['clean'],
-    ],
-  };
-
-  const formats = [
-    'header',
-    'bold',
-    'italic',
-    'underline',
-    'strike',
-    'blockquote',
-    'list',
-    'bullet',
-    'indent',
-    'link',
-    'image',
-    'color',
-    'background',
-  ];
 
   // Data field is needed to set bounds for the editor and avoir tooltip overflow
   return (


### PR DESCRIPTION
Hey, i just made a change to the TextEditor component.
It is now possible to initally add a quillConfig to the mirador config object and use it inside the TextEditor. This allows the plugin users to customize the toolbar and modules of the editor.