### PR TITLE
feat: allow preselection of template type

### DIFF
--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -3,12 +3,15 @@ import annotationPlugins from '../../src';
 import LocalStorageAdapter from '../../src/annotationAdapter/LocalStorageAdapter';
 import { manifestsCatalog } from './manifestsCatalog';
 import { quillConfig } from './quillConfig';
+import { TEMPLATE } from '../../src/annotationForm/AnnotationFormUtils';
 
 const config = {
   annotation: {
     adapter: (canvasId) => new LocalStorageAdapter(`localStorage://?canvasId=${canvasId}`, 'Anonymous User'),
     exportLocalStorageAnnotations: false, // display annotation JSON export button
     quillConfig,
+    // preselect templateType to disable template selection and always use wanted type
+    // templateType: TEMPLATE.TEXT_TYPE,
   },
   annotations: {
     htmlSanitizationRuleSet: 'liberal',

--- a/src/annotationForm/AnnotationForm.js
+++ b/src/annotationForm/AnnotationForm.js
@@ -23,11 +23,13 @@ function AnnotationForm(
     id,
     playerReferences,
     receiveAnnotation,
+    template,
     windowId,
   },
 ) {
   const { t } = useTranslation();
-  const [templateType, setTemplateType] = useState(null);
+
+  const [templateType, setTemplateType] = useState(template);
   // eslint-disable-next-line no-underscore-dangle
   const [mediaType, setMediaType] = useState(playerReferences.getMediaType());
 
@@ -52,7 +54,6 @@ function AnnotationForm(
   }
 
   useEffect(() => {
-    setTemplateType(null);
     setMediaType(playerReferences.getMediaType());
   }, [canvases[0].index]);
 
@@ -205,6 +206,7 @@ AnnotationForm.propTypes = {
   // eslint-disable-next-line react/forbid-prop-types
   playerReferences: PropTypes.object.isRequired,
   receiveAnnotation: PropTypes.func.isRequired,
+  template: PropTypes.string.isRequired,
   windowId: PropTypes.string.isRequired,
 };
 

--- a/src/annotationForm/AnnotationFormTemplateSelector.js
+++ b/src/annotationForm/AnnotationFormTemplateSelector.js
@@ -20,7 +20,7 @@ export default function AnnotationFormTemplateSelector({
    * Sets the comment type for the application.
   */
   const setCommentType = (template) => setCommentingType(template);
-  const templates = TEMPLATE_TYPES(t);
+  const templates = TEMPLATE_TYPES();
 
   return (
     <CardContainer>

--- a/src/annotationForm/AnnotationFormUtils.js
+++ b/src/annotationForm/AnnotationFormUtils.js
@@ -22,7 +22,7 @@ export const MEDIA_TYPES = {
 };
 
 /** Return template type * */
-export const getTemplateType = (t, templateType) => TEMPLATE_TYPES(t)
+export const getTemplateType = (templateType) => TEMPLATE_TYPES()
   .find(
     (type) => type.id === templateType,
   );
@@ -30,36 +30,36 @@ export const getTemplateType = (t, templateType) => TEMPLATE_TYPES(t)
 /**
  * List of the template types supported
  */
-export const TEMPLATE_TYPES = (t) => [
+export const TEMPLATE_TYPES = () => [
   {
-    description: t('textual_note_with_target'),
+    description: 'textual_note_with_target',
     icon: <TextFieldsIcon />,
     id: TEMPLATE.TEXT_TYPE,
     isCompatibleWithTemplate: (mediaType) => {
       if (mediaType === MEDIA_TYPES.IMAGE) return true;
       return false;
     },
-    label: t('note'),
+    label: 'note',
   },
   {
-    description: t('tag_with_target'),
+    description: 'tag_with_target',
     icon: <LocalOfferIcon fontSize="small" />,
     id: TEMPLATE.TAGGING_TYPE,
     isCompatibleWithTemplate: (mediaType) => {
       if (mediaType === MEDIA_TYPES.IMAGE) return true;
       return false;
     },
-    label: t('tag'),
+    label: 'tag',
   },
   {
-    description: t('edit_iiif_json_code'),
+    description: 'edit_iiif_json_code',
     icon: <DataObjectIcon fontSize="small" />,
     id: TEMPLATE.IIIF_TYPE,
     isCompatibleWithTemplate: (mediaType) => {
       if (mediaType === MEDIA_TYPES.IMAGE) return true;
       return false;
     },
-    label: t('expert_mode'),
+    label: 'expert_mode',
   },
 ];
 export const DEFAULT_TOOL_STATE = {

--- a/src/plugins/annotationCreationCompanionWindow.js
+++ b/src/plugins/annotationCreationCompanionWindow.js
@@ -6,6 +6,7 @@ import { OSDReferences } from 'mirador/dist/es/src/plugins/OSDReferences';
 import AnnotationForm from '../annotationForm/AnnotationForm';
 import { WindowPlayer } from '../playerReferences';
 import translations from '../locales/locales';
+import { getTemplateType } from '../annotationForm/AnnotationFormUtils';
 
 /** */
 const mapDispatchToProps = (dispatch, { id, windowId }) => ({
@@ -49,6 +50,7 @@ function mapStateToProps(state, { id: companionWindowId, windowId }) {
     config: { ...state.config, translations },
     currentTime,
     playerReferences,
+    template: getTemplateType(state.config.annotation.templateType) ?? null,
   };
 }
 


### PR DESCRIPTION
Hey,
i just realised that the old solution fetches all the annotation information on every canvas change and not just initaly.
To only the information once i added a processedWindowIds Set which stores the info if the inital annotation information was loaded.